### PR TITLE
chore(deps): relax json-number dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = [ "dep:serde_json", "json-number/serde_json" ]
 all-features = true
 
 [dependencies]
-json-number = { version = "0.4.8", features = [ "smallnumberbuf" ] }
+json-number = { version = "0.4", features = [ "smallnumberbuf" ] }
 smallvec = "1.9"
 smallstr = "0.3"
 locspan = "0.8.2"


### PR DESCRIPTION
Do not specify the patch level of the json-number dependency.

This is also required to consume latest version of the json-number package which addresses RUSTSEC-2023-0086 vulnerability.
